### PR TITLE
Fix for clap changes in lifetimes and get_matches_*

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,13 @@
 name = "clap_derive"
 version = "0.3.0"
 authors = [
-    "Guillaume Pinot <texitoi@texitoi.eu>", 
-    "Kevin K. <kbknapp@gmail.com>", 
+    "Guillaume Pinot <texitoi@texitoi.eu>",
+    "Kevin K. <kbknapp@gmail.com>",
     "hoverbear <andrew@hoverbear.org>"
 ]
 description = "Parse command line argument by defining a struct, derive crate."
 documentation = "https://docs.rs/clap_derive"
-repository = "https://github.com/kbknapp/clap_derive"
+repository = "https://github.com/clap-rs/clap_derive"
 keywords = ["clap", "cli", "derive", "proc_macro", "parse"]
 categories = ["command-line-interface", "development-tools::procedural-macro-helpers"]
 license = "Apache-2.0/MIT"
@@ -18,17 +18,17 @@ readme = "README.md"
 proc-macro = true
 
 [badges]
-travis-ci = { repository = "kbknapp/clap_derive" }
-appveyor = { repository = "https://github.com/kbknapp/clap_derive", service = "github" }
+travis-ci = { repository = "clap-rs/clap_derive" }
+appveyor = { repository = "https://github.com/clap-rs/clap_derive", service = "github" }
 
 [dependencies]
-syn = "0.14"
+syn = "0.15.39"
 quote = "0.6"
 proc-macro2 = "0.4"
 clippy = {version = "0.0.174", optional = true }
 
 [dev-dependencies]
-clap = {git = "https://github.com/kbknapp/clap-rs", branch = "v3-master"} # ONLY FOR INITIAL DEVELOPMENT...change to real crates.io ver for rlease!
+clap = { git = "https://github.com/clap-rs/clap", branch = "v3-master"} # ONLY FOR INITIAL DEVELOPMENT...change to real crates.io ver for rlease!
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 This crate is currently a work in progress and not meant to be used. Please use [`structopt`](https://github.com/TeXitoi/structopt)
 while this crate is being built.
 
-# clap_derive[![Build status](https://travis-ci.org/kbknapp/clap_derive.svg?branch=master)](https://travis-ci.org/kbknapp/clap_derive) [![](https://img.shields.io/crates/v/clap_derive.svg)](https://crates.io/crates/clap_derive) [![](https://docs.rs/clap_derive/badge.svg)](https://docs.rs/clap_derive)
+# clap_derive[![Build status](https://travis-ci.org/clap-rs/clap_derive.svg?branch=master)](https://travis-ci.org/clap-rs/clap_derive) [![](https://img.shields.io/crates/v/clap_derive.svg)](https://crates.io/crates/clap_derive) [![](https://docs.rs/clap_derive/badge.svg)](https://docs.rs/clap_derive)
 
 Parse command line argument by defining a struct.  It combines [structopt](https://github.com/TeXitoi/structopt) and [clap](https://crates.io/crates/clap) into a single experience. This crate is used by clap, and not meant to be used directly by
 consumers.
 
 ## Documentation
 
-Find it on [Docs.rs](https://docs.rs/clap_derive).  You can also check the [examples](https://github.com/kbknapp/clap_derive/tree/master/examples) and the [changelog](https://github.com/kbknapp/clap_derive/blob/master/CHANGELOG.md).
+Find it on [Docs.rs](https://docs.rs/clap_derive).  You can also check the [examples](https://github.com/clap-rs/clap_derive/tree/master/examples) and the [changelog](https://github.com/clap-rs/clap_derive/blob/master/CHANGELOG.md).
 
 ## Example
 
@@ -111,7 +111,7 @@ Opt { debug: true, verbose: 3, speed: 1337, output: "foo.txt", nb_cars: Some(4),
 
 ## clap_derive rustc version policy
 
-- Minimum rustc version modification must be specified in the [changelog](https://github.com/kbknapp/clap_derive/blob/master/CHANGELOG.md) and in the [travis configuration](https://github.com/kbknapp/clap_derive/blob/master/.travis.yml).
+- Minimum rustc version modification must be specified in the [changelog](https://github.com/clap-rs/clap_derive/blob/master/CHANGELOG.md) and in the [travis configuration](https://github.com/clap-rs/clap_derive/blob/master/.travis.yml).
 - Contributors can increment minimum rustc version without any justification if the new version is required by the latest version of one of clap_derive's depedencies (`cargo update` will not fail on clap_derive).
 - Contributors can increment minimum rustc version if the library user experience is improved.
 

--- a/src/derives/clap.rs
+++ b/src/derives/clap.rs
@@ -46,7 +46,7 @@ fn gen_app_augmentation(
                     }
                 };
 
-                Some(quote!{
+                Some(quote! {
                     let #app_var = <#subcmd_type>::augment_app( #app_var );
                     #required
                 })
@@ -111,7 +111,7 @@ fn gen_app_augmentation(
                 };
                 let methods = attrs.methods();
                 let name = attrs.name();
-                Some(quote!{
+                Some(quote! {
                     let #app_var = #app_var.arg(
                         ::clap::Arg::with_name(#name)
                             #modifier
@@ -135,9 +135,9 @@ fn gen_augment_app_fn(
     let app_var = syn::Ident::new("app", proc_macro2::Span::call_site());
     let augmentation = gen_app_augmentation(fields, &app_var);
     quote! {
-        pub fn augment_app<'a, 'b>(
-            #app_var: ::clap::App<'a, 'b>
-        ) -> ::clap::App<'a, 'b> {
+        pub fn augment_app<'b>(
+            #app_var: ::clap::App<'b>
+        ) -> ::clap::App<'b> {
             #augmentation
         }
     }
@@ -177,7 +177,7 @@ fn gen_augment_app_for_enum(
         let from_attrs = attrs.methods();
         quote! {
             .subcommand({
-                let #app_var = ::clap::SubCommand::with_name(#name);
+                let #app_var = ::clap::App::new(#name);
                 let #app_var = #arg_block;
                 #app_var#from_attrs
             })
@@ -185,9 +185,9 @@ fn gen_augment_app_for_enum(
     });
 
     quote! {
-        pub fn augment_app<'a, 'b>(
-            app: ::clap::App<'a, 'b>
-        ) -> ::clap::App<'a, 'b> {
+        pub fn augment_app<'b>(
+            app: ::clap::App<'b>
+        ) -> ::clap::App<'b> {
             app #( #subcommands )*
         }
     }
@@ -220,8 +220,8 @@ fn gen_from_subcommand(
     });
 
     quote! {
-        pub fn from_subcommand<'a, 'b>(
-            sub: (&'b str, Option<&'b ::clap::ArgMatches<'a>>)
+        pub fn from_subcommand<'b>(
+            sub: (&'b str, Option<&'b ::clap::ArgMatches>)
         ) -> Option<Self> {
             match sub {
                 #( #match_arms ),*,
@@ -319,7 +319,7 @@ fn gen_parse_fns(name: &syn::Ident) -> proc_macro2::TokenStream {
 
         fn try_parse() -> ::std::result::Result<#name, ::clap::Error> {
             use ::clap::{FromArgMatches, IntoApp};
-            Ok(#name::from_argmatches(&#name::into_app().get_matches_safe()?))
+            Ok(#name::from_argmatches(&#name::into_app().try_get_matches()?))
         }
 
         fn parse_from<I, T>(itr: I) -> #name
@@ -335,7 +335,7 @@ fn gen_parse_fns(name: &syn::Ident) -> proc_macro2::TokenStream {
             I: ::std::iter::IntoIterator<Item = T>,
             T: Into<::std::ffi::OsString> + Clone {
             use ::clap::{FromArgMatches, IntoApp};
-            Ok(#name::from_argmatches(&#name::into_app().get_matches_from_safe(itr)?))
+            Ok(#name::from_argmatches(&#name::into_app().try_get_matches_from(itr)?))
         }
     }
 }

--- a/src/derives/from_argmatches.rs
+++ b/src/derives/from_argmatches.rs
@@ -46,7 +46,7 @@ pub fn gen_from_argmatches_impl_for_struct(
             #from_argmatches_fn
         }
 
-        impl<'a> From<::clap::ArgMatches<'a>> for #name {
+        impl From<::clap::ArgMatches> for #name {
             fn from(m: ::clap::ArgMatches) -> Self {
                 use ::clap::FromArgMatches;
                 <Self as ::clap::FromArgMatches>::from_argmatches(&m)
@@ -152,7 +152,7 @@ pub fn gen_from_argmatches_impl_for_enum(name: &syn::Ident) -> proc_macro2::Toke
             }
         }
 
-        impl<'a> From<::clap::ArgMatches<'a>> for #name {
+        impl From<::clap::ArgMatches> for #name {
             fn from(m: ::clap::ArgMatches) -> Self {
                 use ::clap::FromArgMatches;
                 <Self as ::clap::FromArgMatches>::from_argmatches(&m)

--- a/src/derives/into_app.rs
+++ b/src/derives/into_app.rs
@@ -43,8 +43,8 @@ pub fn gen_into_app_impl_for_struct(
             #into_app_fn
         }
 
-        impl<'a, 'b> Into<::clap::App<'a, 'b>> for #name {
-            fn into(self) -> ::clap::App<'a, 'b> {
+        impl<'b> Into<::clap::App<'b>> for #name {
+            fn into(self) -> ::clap::App<'b> {
                 use ::clap::IntoApp;
                 <#name as ::clap::IntoApp>::into_app()
             }
@@ -55,7 +55,7 @@ pub fn gen_into_app_impl_for_struct(
 pub fn gen_into_app_fn_for_struct(struct_attrs: &[syn::Attribute]) -> proc_macro2::TokenStream {
     let app = gen_app_builder(struct_attrs);
     quote! {
-        fn into_app<'a, 'b>() -> ::clap::App<'a, 'b> {
+        fn into_app<'b>() -> ::clap::App<'b> {
             Self::augment_app(#app)
         }
     }
@@ -82,8 +82,8 @@ pub fn gen_into_app_impl_for_enum(
             #into_app_fn
         }
 
-        impl<'a, 'b> Into<::clap::App<'a, 'b>> for #name {
-            fn into(self) -> ::clap::App<'a, 'b> {
+        impl<'b> Into<::clap::App<'b>> for #name {
+            fn into(self) -> ::clap::App<'b> {
                 use ::clap::IntoApp;
                 <#name as ::clap::IntoApp>::into_app()
             }
@@ -94,7 +94,7 @@ pub fn gen_into_app_impl_for_enum(
 pub fn gen_into_app_fn_for_enum(enum_attrs: &[syn::Attribute]) -> proc_macro2::TokenStream {
     let gen = gen_app_builder(enum_attrs);
     quote! {
-        fn into_app<'a, 'b>() -> ::clap::App<'a, 'b> {
+        fn into_app<'b>() -> ::clap::App<'b> {
             let app = #gen
                 .setting(::clap::AppSettings::SubcommandRequiredElseHelp);
             Self::augment_app(app)

--- a/tests/arg_enum_basic.rs
+++ b/tests/arg_enum_basic.rs
@@ -30,7 +30,7 @@
 //                 .takes_value(true)
 //                 .possible_values(&ArgChoice::variants()),
 //         )
-//         .get_matches_from_safe(vec!["", "foo"])
+//         .try_get_matches_from(vec!["", "foo"])
 //         .unwrap();
 //     let t = value_t!(matches.value_of("arg"), ArgChoice);
 //     assert!(t.is_ok());
@@ -46,7 +46,7 @@
 //                 .takes_value(true)
 //                 .possible_values(&ArgChoice::variants()),
 //         )
-//         .get_matches_from_safe(vec!["", "Foo"])
+//         .try_get_matches_from(vec!["", "Foo"])
 //         .unwrap();
 //     let t = value_t!(matches.value_of("arg"), ArgChoice);
 //     assert!(t.is_ok());

--- a/tests/arg_enum_case_sensitive.rs
+++ b/tests/arg_enum_case_sensitive.rs
@@ -29,7 +29,7 @@
 //                 .takes_value(true)
 //                 .possible_values(&ArgChoice::variants()),
 //         )
-//         .get_matches_from_safe(vec!["", "foo"]); // We expect this to fail.
+//         .try_get_matches_from(vec!["", "foo"]); // We expect this to fail.
 //     assert!(matches.is_err());
 //     assert_eq!(matches.unwrap_err().kind, clap::ErrorKind::InvalidValue);
 // }
@@ -43,7 +43,7 @@
 //                 .takes_value(true)
 //                 .possible_values(&ArgChoice::variants()),
 //         )
-//         .get_matches_from_safe(vec!["", "Foo"])
+//         .try_get_matches_from(vec!["", "Foo"])
 //         .unwrap();
 //     let t = value_t!(matches.value_of("arg"), ArgChoice);
 //     assert!(t.is_ok());

--- a/tests/nested-subcommands.rs
+++ b/tests/nested-subcommands.rs
@@ -189,7 +189,7 @@ fn sub_sub_cmd_with_option() {
         use clap::{FromArgMatches, IntoApp};
 
         SubSubCmdWithOption::into_app()
-            .get_matches_from_safe(args)
+            .try_get_matches_from(args)
             .ok()
             .map(|m| SubSubCmdWithOption::from_argmatches(&m))
     }


### PR DESCRIPTION
The tests still won't work because clap and clap_derive are interdependent. But this is a first step to fixing the whole thing.