### PR TITLE
refactor: Do not use cargo description as default

### DIFF
--- a/src/derives/attrs.rs
+++ b/src/derives/attrs.rs
@@ -254,7 +254,6 @@ impl Attrs {
         let mut res = Self::new(name);
         let attrs_with_env = [
             ("version", "CARGO_PKG_VERSION"),
-            ("about", "CARGO_PKG_DESCRIPTION"),
             ("author", "CARGO_PKG_AUTHORS"),
         ];
         attrs_with_env

--- a/tests/author_version.rs
+++ b/tests/author_version.rs
@@ -22,7 +22,7 @@ fn no_author_version_about() {
     use clap::IntoApp;
 
     #[derive(Clap, PartialEq, Debug)]
-    #[clap(name = "foo", about = "", author = "", version = "")]
+    #[clap(name = "foo", author = "", version = "")]
     struct Opt {}
 
     let mut output = Vec::new();
@@ -34,7 +34,6 @@ fn no_author_version_about() {
 
 static ENV_HELP: &str = "clap_derive 0.3.0
 Guillaume Pinot <texitoi@texitoi.eu>, Kevin K. <kbknapp@gmail.com>, hoverbear <andrew@hoverbear.org>
-Parse command line argument by defining a struct, derive crate.
 
 USAGE:
     clap_derive


### PR DESCRIPTION
Currently, the pkg description is used as default for every clap app (which includes subcommands). Thus, it gets very repetitive which does not look good. It's preferable to have empty descriptions rather the same one multiple times.

It also allows the situation where author would intentionally leave the description empty